### PR TITLE
Implemented login API handler to authenticate credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ web_modules/
 
 # Optional eslint cache
 .eslintcache
+.eslintrc.js
 
 # Optional stylelint cache
 .stylelintcache

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -5,7 +5,20 @@ import User from "../models/userModel.js";
 // @route   POST /api/users/auth
 // @access  Public
 const authUser = asyncHandler(async (request, response) => {
-  response.status(200).json({ message: "User authentication successful" });
+  const { email, password } = request.body;
+
+  const user = await User.findOne({ email });
+
+  if (user && (await user.matchPassword(password))) {
+    response.status(201).json({
+      _id: user._id,
+      name: user.name,
+      email: user.email,
+    });
+  } else {
+    response.status(401);
+    throw new Error("Invalid email or password");
+  }
 });
 
 // @desc    Register a new user

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -37,7 +37,7 @@ const registerUser = asyncHandler(async (request, response) => {
   const user = await User.create({ name, email, password });
 
   if (user) {
-    response.status(201).json({
+    response.status(200).json({
       _id: user._id,
       name: user.name,
       email: user.email,

--- a/server/models/userModel.js
+++ b/server/models/userModel.js
@@ -32,6 +32,11 @@ userSchema.pre("save", async function (next) {
   this.password = await bcrypt.hash(this.password, salt);
 });
 
+// Check decrypted password for logging in
+userSchema.methods.matchPassword = async function (enteredPassword) {
+  return await bcrypt.compare(enteredPassword, this.password);
+};
+
 const User = mongoose.model("User", userSchema);
 
 export default User;

--- a/server/models/userModel.js
+++ b/server/models/userModel.js
@@ -32,6 +32,11 @@ userSchema.pre("save", async function (next) {
   this.password = await bcrypt.hash(this.password, salt);
 });
 
+// Check decrypted password for logging in
+userSchema.methods.matchPassword = async function(enteredPassword) {
+  return await bcrypt.compare(enteredPassword, this.password);
+}
+
 const User = mongoose.model("User", userSchema);
 
 export default User;


### PR DESCRIPTION
We can now successfully log a user in using email and password, which is checked against the data in our database. The password is checked against the decrypted password from the database.
** Prettier has been run **
<img width="562" alt="Screenshot 2023-09-27 at 2 59 57 PM" src="https://github.com/Dining-Philosophers-Tweello/tweello/assets/59898052/fc63a3bb-6c3b-44a7-8ee7-deab83d0da53">

Using the correct credentials proves the authentication:
<img width="571" alt="Screenshot 2023-09-27 at 2 59 40 PM" src="https://github.com/Dining-Philosophers-Tweello/tweello/assets/59898052/ce399677-f647-4c9d-969d-1052e79f942a">

Using the incorrect credentials shows an error message:
<img width="803" alt="Screenshot 2023-09-27 at 3 00 25 PM" src="https://github.com/Dining-Philosophers-Tweello/tweello/assets/59898052/509f1512-00d9-4e28-b50f-0fa4239ca1b4">
