### PR TITLE
TWEEL 54: Delete workspace API

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -1,12 +1,11 @@
 import cookieParser from "cookie-parser";
+import cors from "cors";
 import dotenv from "dotenv";
 import express from "express";
 import connectDB from "./config/db.js";
 import { errorHandler, notFound } from "./middleware/errorMiddleware.js";
 import userRoutes from "./routes/userRoutes.js";
 import workspaceRoutes from "./routes/workspaceRoutes.js";
-import cors from 'cors'
-
 
 dotenv.config();
 const port = process.env.PORT;

--- a/server/controllers/workspaceController.js
+++ b/server/controllers/workspaceController.js
@@ -1,10 +1,9 @@
 import asyncHandler from "express-async-handler";
 import Workspace from "../models/workspaceModel.js";
-import User from "../models/userModel.js";
 
 // @desc    Create a new workspace
 // @route   POST /api/workspaces
-// @access  Public
+// @access  Private
 const createWorkspace = asyncHandler(async (request, response) => {
   const { name } = request.body;
   const creator = request.user._id;
@@ -32,4 +31,28 @@ const createWorkspace = asyncHandler(async (request, response) => {
   response.status(200).json({ message: "Success" });
 });
 
-export { createWorkspace };
+// @desc    Delete a workspace
+// @route   DELETE /api/workspaces/:id
+// @access  Private
+const deleteWorkspace = asyncHandler(async (request, response) => {
+  const id = request.params.id;
+  const user = request.user._id;
+
+  const workspace = await Workspace.findById(id);
+
+  if (!workspace) {
+    response.status(404);
+    throw new Error("Workspace not found");
+  }
+
+  if (workspace.creator.toString() !== user.toString()) {
+    response.status(401);
+    throw new Error("Only the creator can delete this workspace");
+  }
+
+  await Workspace.deleteOne({ _id: id });
+
+  response.status(200).json({ message: "Workspace deleted" });
+});
+
+export { createWorkspace, deleteWorkspace };

--- a/server/routes/workspaceRoutes.js
+++ b/server/routes/workspaceRoutes.js
@@ -1,9 +1,13 @@
 import express from "express";
-import { createWorkspace } from "../controllers/workspaceController.js";
+import {
+  createWorkspace,
+  deleteWorkspace,
+} from "../controllers/workspaceController.js";
 import { protect } from "../middleware/authMiddleware.js";
 
 const router = express.Router();
 
 router.route("/").post(protect, createWorkspace);
+router.route("/:id").delete(protect, deleteWorkspace);
 
 export default router;


### PR DESCRIPTION
## Description
- Created create workspace api endpoint at /api/workspace
- Included validation for if the workspace exists + if the user is the creator of the workspace

## Demo
### Postman + MongoDB testing
[Postman API Call](https://dining-philosophers.postman.co/workspace/Tweello~60172c91-5d9e-4f81-b26e-456899cfb3eb/request/29866910-48c315f5-c686-47a2-9067-b2ceae62d311?action=share&creator=29866910&ctx=documentation&active-environment=25430117-600c0575-946c-47bb-8c18-4c526644899a)
1. Log in
2. Create a workspace
3. Get the ID of that workspace, go to `[Delete Workspace] - /workspaces/:id` Postman call
4. Insert workspace ID like the following: `{{baseURL}}/workspaces/65272874913a00b12b5dfe04`
5. Send the request, and the workspace should be deleted