### PR TITLE
TWEEL 138: Delete workspace frontend

### DIFF
--- a/client/src/app/workspace/[id]/page.tsx
+++ b/client/src/app/workspace/[id]/page.tsx
@@ -122,7 +122,7 @@ export default function WorkspacePage({ params }: { params: { id: string } }) {
             </DialogContent>
           </Dialog>
           <ShareWorkspaceDialog workspaceId={params.id} />
-          <DeleteWorkspaceDialog />
+          <DeleteWorkspaceDialog workspaceId={params.id} />
         </div>
         <div className="flex gap-5 flex-wrap">
           {boardsData.map((board) => (

--- a/client/src/components/delete-workspace-dialog.tsx
+++ b/client/src/components/delete-workspace-dialog.tsx
@@ -1,5 +1,4 @@
 import { Button } from "@/components/ui/button";
-
 import {
   Dialog,
   DialogClose,
@@ -10,8 +9,35 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import { useRouter } from "next/navigation";
 
-const DeleteWorkspaceDialog = () => {
+const DeleteWorkspaceDialog = ({ workspaceId }: { workspaceId: string }) => {
+  const router = useRouter();
+  const handleSubmit = () => {
+    const jwt = localStorage.getItem("jwt");
+    const requestOptions = {
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+      },
+    };
+
+    fetch(`http://localhost:8000/api/workspaces/${workspaceId}`, requestOptions)
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error("Network response was not ok");
+        }
+
+        return response.json();
+      })
+      .then(() => {
+        router.replace("/home");
+      })
+      .catch((error) => {
+        console.error("Error deleting workspace:", error);
+      });
+  };
+
   return (
     <Dialog>
       <DialogTrigger>
@@ -33,7 +59,12 @@ const DeleteWorkspaceDialog = () => {
             </Button>
           </DialogClose>
           <DialogClose asChild>
-            <Button className="w-1/2 mr-2" variant="destructive" type="submit">
+            <Button
+              className="w-1/2 mr-2"
+              variant="destructive"
+              type="submit"
+              onClick={handleSubmit}
+            >
               Delete
             </Button>
           </DialogClose>

--- a/client/src/components/workspace-dialog.tsx
+++ b/client/src/components/workspace-dialog.tsx
@@ -93,7 +93,7 @@ export default function WorkspaceDialog() {
       .catch((error) => {
         console.error("Error fetching workspaces:", error);
       });
-  }, []);
+  });
 
   return (
     <Dialog


### PR DESCRIPTION
## Description
- Set workspaces fetch `useEffect()` function to be called on every render so that it updates when a workspace is deleted
- Implemented API call for deleting a workspace

## Demo
- Delete workspace dialog:
![localhost_3000_workspace_653829829751b0f9d4af6885](https://github.com/Dining-Philosophers-Tweello/tweello/assets/37820188/7b7f7213-7c47-4ef4-92e4-e13a035bde68)
- After confirming deletion, route is replaced to `/home`, workspace no longer shows in dropdown due to `useEffect()` re-render
![localhost_3000_workspace_653829829751b0f9d4af6885 (2)](https://github.com/Dining-Philosophers-Tweello/tweello/assets/37820188/8c0e91c9-5a12-44ea-aaa7-0fbe6379aaee)
