### PR TITLE
TWEEL 129: Create board frontend

### DIFF
--- a/client/src/app/home/page.tsx
+++ b/client/src/app/home/page.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import CreateWorkspaceDialog from "@/components/create-workspace-dialog";
 import { Icons } from "@/components/icons";
 import { WorkspaceBoardCard } from "@/components/workspace-board-card";
+import { requestOptions } from "@/hooks/requestOptions";
 import { Workspace } from "@/types";
 import { useEffect, useState } from "react";
 
@@ -9,16 +11,7 @@ export default function Home() {
   const [workspaces, setWorkspaces] = useState<Workspace[] | null>();
 
   useEffect(() => {
-    const jwt = localStorage.getItem("jwt");
-    const requestOptions = {
-      method: "GET",
-      headers: {
-        Authorization: `Bearer ${jwt}`,
-        "Content-Type": "application/json",
-      },
-    };
-
-    fetch("http://localhost:8000/api/workspaces", requestOptions)
+    fetch("http://localhost:8000/api/workspaces", requestOptions("GET"))
       .then((response) => {
         if (!response.ok) {
           throw new Error("Network response was not ok");
@@ -52,15 +45,21 @@ export default function Home() {
           </div>
         ) : (
           <>
-            {workspaces.map((workspace) => (
-              <WorkspaceBoardCard
-                key={workspace._id}
-                link={`/workspaces/${workspace._id}`}
-                title={workspace.name}
-                updatedAt={workspace.updatedAt}
-                createdAt={workspace.createdAt}
-              />
-            ))}
+            <div className="flex flex-row gap-3">
+              <div className="text-4xl font-bold">Your Workspaces</div>
+              <CreateWorkspaceDialog />
+            </div>
+            <div className="flex flex-row w-screen h-fit flex-wrap gap-5">
+              {workspaces.map((workspace) => (
+                <WorkspaceBoardCard
+                  key={workspace._id}
+                  link={`/workspaces/${workspace._id}`}
+                  title={workspace.name}
+                  updatedAt={workspace.updatedAt}
+                  createdAt={workspace.createdAt}
+                />
+              ))}
+            </div>
           </>
         )}
       </div>

--- a/client/src/app/workspaces/[workspaceId]/boards/[boardId]/page.tsx
+++ b/client/src/app/workspaces/[workspaceId]/boards/[boardId]/page.tsx
@@ -3,6 +3,7 @@
 import DeleteDialog from "@/components/delete-dialog";
 import EditBoardDialog from "@/components/edit-board-dialog";
 import { Icons } from "@/components/icons";
+import { requestOptions } from "@/hooks/requestOptions";
 import { Board, nullBoard } from "@/types";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -17,18 +18,9 @@ export default function Board({
   const [board, setBoard] = useState<Board | null>();
 
   useEffect(() => {
-    const jwt = localStorage.getItem("jwt");
-    const requestOptions = {
-      method: "GET",
-      headers: {
-        Authorization: `Bearer ${jwt}`,
-        "Content-Type": "application/json",
-      },
-    };
-
     fetch(
       `http://localhost:8000/api/workspaces/${params.workspaceId}/boards/${params.boardId}`,
-      requestOptions,
+      requestOptions("GET"),
     )
       .then((response) => {
         if (!response.ok) {
@@ -46,17 +38,9 @@ export default function Board({
   });
 
   const handleDelete = () => {
-    const jwt = localStorage.getItem("jwt");
-    const requestOptions = {
-      method: "DELETE",
-      headers: {
-        Authorization: `Bearer ${jwt}`,
-      },
-    };
-
     fetch(
       `http://localhost:8000/api/workspaces/${params.workspaceId}/boards/${params.boardId}`,
-      requestOptions,
+      requestOptions("DELETE"),
     )
       .then((response) => {
         if (!response.ok) {
@@ -90,7 +74,7 @@ export default function Board({
       ) : (
         <div className="flex flex-col gap-5 p-5 w-screen h-screen">
           <div className="flex flex-row gap-5">
-            <div className="text-3xl">{board.name}</div>
+            <div className="text-4xl font-bold">{board.name}</div>
             <EditBoardDialog
               boardName={board.name}
               boardDescription={board.description}

--- a/client/src/app/workspaces/[workspaceId]/page.tsx
+++ b/client/src/app/workspaces/[workspaceId]/page.tsx
@@ -5,6 +5,7 @@ import DeleteDialog from "@/components/delete-dialog";
 import { Icons } from "@/components/icons";
 import ShareWorkspaceDialog from "@/components/share-workspace-dialog";
 import { WorkspaceBoardCard } from "@/components/workspace-board-card";
+import { requestOptions } from "@/hooks/requestOptions";
 import { Workspace, nullWorkspace } from "@/types";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -18,18 +19,9 @@ export default function WorkspacePage({
   const router = useRouter();
 
   useEffect(() => {
-    const jwt = localStorage.getItem("jwt");
-    const requestOptions = {
-      method: "GET",
-      headers: {
-        Authorization: `Bearer ${jwt}`,
-        "Content-Type": "application/json",
-      },
-    };
-
     fetch(
       `http://localhost:8000/api/workspaces/${params.workspaceId}`,
-      requestOptions,
+      requestOptions("GET"),
     )
       .then((response) => {
         if (!response.ok) {
@@ -44,26 +36,17 @@ export default function WorkspacePage({
         setWorkspace(nullWorkspace);
         console.error("Error fetching workspaces:", error);
       });
-  }, []);
+  });
 
   const handleDelete = () => {
-    const jwt = localStorage.getItem("jwt");
-    const requestOptions = {
-      method: "DELETE",
-      headers: {
-        Authorization: `Bearer ${jwt}`,
-      },
-    };
-
     fetch(
       `http://localhost:8000/api/workspaces/${params.workspaceId}`,
-      requestOptions,
+      requestOptions("DELETE"),
     )
       .then((response) => {
         if (!response.ok) {
           throw new Error("Network response was not ok");
         }
-
         return response.json();
       })
       .then(() => {
@@ -91,8 +74,8 @@ export default function WorkspacePage({
       ) : (
         <div className="flex flex-col gap-5 p-5 w-screen h-screen">
           <div className="flex flex-row gap-5">
-            <div className="text-3xl">{workspace.name}</div>
-            <CreateBoardDialog />
+            <div className="text-4xl font-bold">{workspace.name}</div>
+            <CreateBoardDialog params={params} />
             <ShareWorkspaceDialog workspaceId={params.workspaceId} />
             <DeleteDialog
               componentName={"Workspace"}

--- a/client/src/components/create-workspace-dialog.tsx
+++ b/client/src/components/create-workspace-dialog.tsx
@@ -1,0 +1,101 @@
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { requestOptions } from "@/hooks/requestOptions";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+export default function CreateWorkspaceDialog() {
+  const [open, setOpen] = useState(false);
+  const router = useRouter();
+  const [newWorkspaceName, setNewWorkspaceName] = useState("");
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setNewWorkspaceName(e.target.value);
+  };
+
+  const handleSubmit = () => {
+    fetch(
+      "http://localhost:8000/api/workspaces",
+      requestOptions("POST", { name: newWorkspaceName }),
+    )
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error("Network response was not ok");
+        }
+        return response.json();
+      })
+      .then((data) => {
+        router.push(`/workspaces/${data._id}`);
+        setNewWorkspaceName("");
+      })
+      .catch((error) => {
+        console.error("Error creating workspace:", error);
+      });
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={() => {
+        setOpen(!open);
+        setNewWorkspaceName("");
+      }}
+    >
+      <DialogTrigger>
+        <Button>Create New Workspace</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleSubmit();
+            setOpen(false);
+          }}
+        >
+          <DialogHeader>
+            <DialogTitle>Create New Workspace</DialogTitle>
+            <DialogDescription></DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-4 py-4">
+            <div className="grid  items-center gap-4">
+              <Label htmlFor="name" className="text-left text-sm">
+                Workspace Name
+              </Label>
+              <Input
+                id="workspace-name"
+                name="workspace-name"
+                type="text"
+                autoCapitalize="none"
+                autoCorrect="off"
+                onChange={handleChange}
+                className="col-span-3"
+                placeholder="Enter workspace name"
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button className="mr-2" variant="secondary">
+                Cancel
+              </Button>
+            </DialogClose>
+            <Button type="submit" disabled={newWorkspaceName == ""}>
+              Create
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/components/profile-dialog.tsx
+++ b/client/src/components/profile-dialog.tsx
@@ -16,6 +16,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { requestOptions } from "@/hooks/requestOptions";
 import { signOut } from "next-auth/react";
 
 const ProfileDialog = () => {
@@ -25,21 +26,11 @@ const ProfileDialog = () => {
   };
 
   const handleSubmit = async () => {
-    const jwt = localStorage.getItem("jwt");
-    const requestOptions = {
-      method: "DELETE",
-      headers: {
-        Authorization: `Bearer ${jwt}`,
-        "Content-Type": "application/json",
-      },
-    };
-
     try {
       const response = await fetch(
         "http://localhost:8000/api/users/profile",
-        requestOptions,
+        requestOptions("DELETE"),
       );
-
       if (response.ok) {
         await handleSignout();
       }

--- a/client/src/components/profile-settings-dialog.tsx
+++ b/client/src/components/profile-settings-dialog.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { requestOptions } from "@/hooks/requestOptions";
 import { DialogClose } from "@radix-ui/react-dialog";
 import { Settings } from "lucide-react";
 import { ChangeEvent, FormEvent, useEffect, useState } from "react";
@@ -26,21 +27,11 @@ const ProfileSettingsDialog = () => {
   });
 
   useEffect(() => {
-    const jwt = localStorage.getItem("jwt");
-    const requestOptions = {
-      method: "GET",
-      headers: {
-        Authorization: `Bearer ${jwt}`,
-        "Content-Type": "application/json",
-      },
-    };
-
-    fetch("http://localhost:8000/api/users/profile", requestOptions)
+    fetch("http://localhost:8000/api/users/profile", requestOptions("GET"))
       .then((response) => {
         if (!response.ok) {
           throw new Error("Network response was not ok");
         }
-
         return response.json();
       })
       .then((data) => {
@@ -59,42 +50,27 @@ const ProfileSettingsDialog = () => {
 
   const validateField = (name: string, value: string) => {
     let errorMessage = "";
-
     if (name === "name") {
       if (value.trim() === "") {
         errorMessage = "Name is required";
       }
     }
-
     setErrors({ ...errors, [name]: errorMessage });
   };
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
-
     const { name } = profile;
     validateField("name", name);
-
     if (!errors.name) {
       const body = {
         ...(profile.name && { name: profile.name }),
       };
-      const jwt = localStorage.getItem("jwt");
-      const requestOptions = {
-        method: "PUT",
-        body: JSON.stringify(body),
-        headers: {
-          Authorization: `Bearer ${jwt}`,
-          "Content-Type": "application/json",
-        },
-      };
-
       try {
         const response = await fetch(
           "http://localhost:8000/api/users/profile",
-          requestOptions,
+          requestOptions("PUT", body),
         );
-
         if (response.ok) {
           setOpen(false);
         }

--- a/client/src/components/workspace-board-card.tsx
+++ b/client/src/components/workspace-board-card.tsx
@@ -39,15 +39,19 @@ export const WorkspaceBoardCard = ({
       <div className="flex flex-col gap-3">
         <div className="text-xl">{title}</div>
         <div className="font-light text-gray-500">{displayDesc}</div>
-        {updatedAtDate && createdAtDate && (
-          <div className="font-light text-sm text-gray-500">
-            <div>Last updated {updatedAtDate.fromNow()} </div>
-            <div>Created {createdAtDate.fromNow()} </div>
+        <div className="flex flex-row items-end justify-between">
+          <div>
+            {updatedAtDate && createdAtDate && (
+              <div className="font-light text-sm text-gray-500">
+                <div>Last updated {updatedAtDate.fromNow()} </div>
+                <div>Created {createdAtDate.fromNow()} </div>
+              </div>
+            )}
           </div>
-        )}
-      </div>
-      <div className="flex justify-end">
-        <ArrowRight className="text-gray-400" size={24} />
+          <div className="flex justify-end">
+            <ArrowRight className="text-gray-400" size={24} />
+          </div>
+        </div>
       </div>
     </Link>
   );

--- a/client/src/components/workspace-dropdown.tsx
+++ b/client/src/components/workspace-dropdown.tsx
@@ -1,14 +1,4 @@
-import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog";
+import { Dialog } from "@/components/ui/dialog";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -16,8 +6,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
+import { requestOptions } from "@/hooks/requestOptions";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -31,52 +20,9 @@ export default function WorkspaceDropdown() {
   const [open, setOpen] = useState(false);
   const router = useRouter();
   const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
-  const [newWorkspaceName, setNewWorkspaceName] = useState("");
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setNewWorkspaceName(e.target.value);
-  };
-
-  const handleSubmit = () => {
-    const jwt = localStorage.getItem("jwt");
-    const requestOptions = {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${jwt}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ name: newWorkspaceName }),
-    };
-
-    fetch("http://localhost:8000/api/workspaces", requestOptions)
-      .then((response) => {
-        if (!response.ok) {
-          throw new Error("Network response was not ok");
-        }
-
-        return response.json();
-      })
-      .then((data) => {
-        setWorkspaces([...workspaces, { id: data._id, name: data.name }]);
-        router.push(`/workspaces/${data._id}`);
-        setNewWorkspaceName("");
-      })
-      .catch((error) => {
-        console.error("Error creating workspace:", error);
-      });
-  };
 
   useEffect(() => {
-    const jwt = localStorage.getItem("jwt");
-    const requestOptions = {
-      method: "GET",
-      headers: {
-        Authorization: `Bearer ${jwt}`,
-        "Content-Type": "application/json",
-      },
-    };
-
-    fetch("http://localhost:8000/api/workspaces", requestOptions)
+    fetch("http://localhost:8000/api/workspaces", requestOptions("GET"))
       .then((response) => {
         if (!response.ok) {
           throw new Error("Network response was not ok");
@@ -101,7 +47,6 @@ export default function WorkspaceDropdown() {
       open={open}
       onOpenChange={() => {
         setOpen(!open);
-        setNewWorkspaceName("");
       }}
     >
       <DropdownMenu>
@@ -115,11 +60,8 @@ export default function WorkspaceDropdown() {
               setOpen(false);
             }}
           >
-            Home
+            <div className="flex flex-row gap-1 font-bold">Home</div>
           </DropdownMenuItem>
-          <DialogTrigger asChild>
-            <DropdownMenuItem>Create New Workspace</DropdownMenuItem>
-          </DialogTrigger>
           {workspaces.length > 0 && <DropdownMenuSeparator />}
           {workspaces.map((workspace) => {
             return (
@@ -132,47 +74,6 @@ export default function WorkspaceDropdown() {
           })}
         </DropdownMenuContent>
       </DropdownMenu>
-      <DialogContent>
-        <form
-          onSubmit={(e) => {
-            e.preventDefault();
-            handleSubmit();
-            setOpen(false);
-          }}
-        >
-          <DialogHeader>
-            <DialogTitle>Create New Workspace</DialogTitle>
-            <DialogDescription></DialogDescription>
-          </DialogHeader>
-          <div className="grid gap-4 py-4">
-            <div className="grid  items-center gap-4">
-              <Label htmlFor="name" className="text-left text-sm">
-                Workspace Name
-              </Label>
-              <Input
-                id="workspace-name"
-                name="workspace-name"
-                type="text"
-                autoCapitalize="none"
-                autoCorrect="off"
-                onChange={handleChange}
-                className="col-span-3"
-                placeholder="Enter workspace name"
-              />
-            </div>
-          </div>
-          <DialogFooter>
-            <DialogClose asChild>
-              <Button className="mr-2" variant="secondary">
-                Cancel
-              </Button>
-            </DialogClose>
-            <Button type="submit" disabled={newWorkspaceName == ""}>
-              Create
-            </Button>
-          </DialogFooter>
-        </form>
-      </DialogContent>
     </Dialog>
   );
 }

--- a/client/src/hooks/requestOptions.ts
+++ b/client/src/hooks/requestOptions.ts
@@ -1,0 +1,23 @@
+export const requestOptions = (method: string, payload?: string | Object) => {
+  const jwt = localStorage.getItem("jwt");
+  const headers = {
+    Authorization: `Bearer ${jwt}`,
+    "Content-Type": "application/json",
+  };
+  if (method === "GET" || method === "DELETE") {
+    return {
+      method: method,
+      headers: headers,
+    };
+  } else if (method === "POST" || method === "PUT") {
+    return {
+      method: method,
+      headers: headers,
+      body: JSON.stringify(payload),
+    };
+  } else {
+    return {
+      Error: "Invalid requestOptions() call",
+    };
+  }
+};


### PR DESCRIPTION
## Description
- Added functionality to create board modal

### Unrelated optimizations and changes
- Created `/client/hooks/responseOptions.ts` function to minimize repeated code in our frontend fetches
- Transferred create workspace component from navbar dropdown to homepage
   <img width="921" alt="image" src="https://github.com/Dining-Philosophers-Tweello/tweello/assets/37820188/46f74ac4-dafe-402a-96ad-db78be3e5aef">
- Edited share workspace dialog to display users that the workspace is currently shared with:
   <img width="539" alt="image" src="https://github.com/Dining-Philosophers-Tweello/tweello/assets/37820188/6ca43d5e-1d46-4cfe-901c-6d6ac6766993">
- Edited behavior of some forms to correctly repopulate fields when dialog is not submitted/canceled
